### PR TITLE
fix: change input parameter to repo-token

### DIFF
--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -10,5 +10,5 @@ jobs:
           ref: release/master
       - uses: ./
         with:
-          github-token: ${{ github.token }}
+          repo-token: ${{ github.token }}
           clean: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,4 +21,4 @@ jobs:
           npm test
       - uses: ./
         with:
-          github-token: ${{ github.token }}
+          repo-token: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following example will create a release in the format `X.Y.Z`
 ```
       - uses: playstudios/action-release-action@v1
         with:
-          github-token: ${{ github.token }}
+          repo-token: ${{ github.token }}
           tag-prefix: ''
 ```
 
@@ -32,7 +32,7 @@ The following example will create a release in the format `mysuperrelease-X.Y.Z`
 ```
       - uses: playstudios/action-release-action@v1
         with:
-          github-token: ${{ github.token }}
+          repo-token: ${{ github.token }}
           tag-prefix: 'mysuperrelease-'
 ```
 
@@ -66,7 +66,7 @@ jobs:
           npm run pack
       - uses: playstudios/action-release-action@v1
         with:
-          github-token: ${{ github.token }}
+          repo-token: ${{ github.token }}
 ```
 
 To clean up obsolete release branches:
@@ -81,6 +81,6 @@ jobs:
     steps:
       - uses: playstudios/action-release-action@v1
         with:
-          github-token: ${{ github.token }}
+          repo-token: ${{ github.token }}
           clean: true
 ```

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: Release Action
 description: Release action with semantic release
 author: PlayStudios
 inputs:
-  github-token:
+  repo-token:
     description: GitHub token
     required: true
   clean:

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ const clean = async () => {
   }
 
   const branch = `release/${github.context.payload.ref}`
-  const octokit = github.getOctokit(core.getInput('github-token'))
+  const octokit = github.getOctokit(core.getInput('repo-token'))
   const ref = await octokit.rest.git.getRef({ ...github.context.repo, ref: `heads/${branch}` }).catch((e) => e)
 
   if (ref.data) {
@@ -86,7 +86,7 @@ const release = async () => {
     const result = await semanticRelease(options, {
       env: {
         ...process.env,
-        GITHUB_TOKEN: core.getInput('github-token'),
+        GITHUB_TOKEN: core.getInput('repo-token'),
         GITHUB_REF: branch,
       },
     })


### PR DESCRIPTION
the repositories which using `action-semantic-release` are using variable input `repo-token`
so this change will let us DRY when changing to `action-release-action`