### PR TITLE
fix: move index import after the node dependency import

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path'
 import { exec } from "./src/exec.js"
-import { releaseActionMain } from "./src/index.js"
 
 const run = async () => {
   // Install Dependencies
@@ -16,6 +15,7 @@ const run = async () => {
     }
   }
 
+  releaseActionMain = await import('./src/index.js')
   releaseActionMain()
 }
 


### PR DESCRIPTION
Action sometimes failing with missing dependencies. Moved import after dependency pull.