### PR TITLE
fix: update action exit condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,12 +6,13 @@ const run = async () => {
   // Install Dependencies
   {
     const __dirname = dirname(fileURLToPath(import.meta.url));
-    const { stdout, stderr } = await exec('npm install && npm --loglevel error ci --only=prod', {
+    const { error, stdout, _ } = await exec('npm install && npm --loglevel error ci --only=prod', {
       cwd: resolve(__dirname),
     })
     console.log(stdout)
-    if (stderr) {
-      return Promise.reject(stderr)
+    if (error) {
+      console.log('Got ERROR')
+      return Promise.reject(error)
     }
   }
 


### PR DESCRIPTION
Changed action exit condition to take into account npm install WARNs that are also published to stderr. These should not stop the action from executing. Currently a warning is posted related to an indirect dependency pulled by @semantic-release/release-notes-generator